### PR TITLE
Remove unused submodule

### DIFF
--- a/documentation/generate_docs.py
+++ b/documentation/generate_docs.py
@@ -269,7 +269,7 @@ class DocumentationGenerator:
 
         # Main project structure
         structure.extend([
-            "Root Directory: Warcraft3-website\n",
+            "Root Directory\n",
             "Main Application Files",
             "-------------------"
         ])


### PR DESCRIPTION
## Summary
- drop the unused `Warcraft3-website/` submodule entry
- update documentation generator text

## Testing
- `python documentation/generate_docs.py` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_683f97e0313c83228531d795aa34fef9

## Summary by Sourcery

Remove the unused Warcraft3-website submodule and update the documentation generator to reflect the change.

Enhancements:
- Simplify the root directory label in the generate_docs script by removing the specific submodule name.

Chores:
- Drop the unused Warcraft3-website submodule directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/manuelaidos123/Warcraft3-website/3)
<!-- Reviewable:end -->
